### PR TITLE
Fix for clicking slider (and not dragging)

### DIFF
--- a/lib/component/Slider_Internal.js
+++ b/lib/component/Slider_Internal.js
@@ -66,6 +66,7 @@ Slider_Internal.prototype._onSlotMouseDown = function(){
     this._handle.dragging = true;
     this._handle.node.getElement().focus();
     this._update();
+    this._onChange();
 };
 
 Slider_Internal.prototype._onSlotMouseUp = function(){


### PR DESCRIPTION
Right now, if you click on a slider without dragging it, it'll weirdly update the value without actually making the change. That's because it only calls this._onChange() on mousemove events, not on mousedown events.